### PR TITLE
Coding_convention FAQ->Faq 변수명아닌것까지 바뀌어버리는 문제 해결

### DIFF
--- a/jibcon/src/main/java/com/sm_arts/jibcon/app/setting/usercenter/UserCenter.java
+++ b/jibcon/src/main/java/com/sm_arts/jibcon/app/setting/usercenter/UserCenter.java
@@ -19,7 +19,7 @@ import com.sm_arts.jibcon.app.setting.SettingActivity;
 public class UserCenter extends AppCompatActivity {
 
     ListView mSettingUserCenterLv;
-    static final String[] sSettingUserCenterList={"제조업체 문의","Faq","집콘 문의하기"};
+    static final String[] sSettingUserCenterList={"제조업체 문의","FAQ","집콘 문의하기"};
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
UserCenter.java에서 mSettingUserCenterList의 2번째 string도 FAQ인데 이건 바뀌면 안될것 같습니다. #42

String 변경